### PR TITLE
Cast address down to uint128

### DIFF
--- a/src/BucketDLL.sol
+++ b/src/BucketDLL.sol
@@ -5,33 +5,33 @@ library BucketDLL {
     /// STRUCTS ///
 
     struct Account {
-        address prev;
-        address next;
+        uint128 prev;
+        uint128 next;
     }
 
     struct List {
-        mapping(address => Account) accounts;
+        mapping(uint128 => Account) accounts;
     }
 
     /// INTERNAL ///
 
     /// @notice Returns the address at the head of the `_list`.
     /// @param _list The list from which to get the head.
-    function getHead(List storage _list) internal view returns (address) {
-        return _list.accounts[address(0)].next;
+    function getHead(List storage _list) internal view returns (uint128) {
+        return _list.accounts[0].next;
     }
 
     /// @notice Returns the address at the tail of the `_list`.
     /// @param _list The list from which to get the tail.
-    function getTail(List storage _list) internal view returns (address) {
-        return _list.accounts[address(0)].prev;
+    function getTail(List storage _list) internal view returns (uint128) {
+        return _list.accounts[0].prev;
     }
 
     /// @notice Returns the next id address from the current `_id`.
     /// @param _list The list to search in.
     /// @param _id The address of the current account.
     /// @return The address of the next account.
-    function getNext(List storage _list, address _id) internal view returns (address) {
+    function getNext(List storage _list, uint128 _id) internal view returns (uint128) {
         return _list.accounts[_id].next;
     }
 
@@ -39,7 +39,7 @@ library BucketDLL {
     /// @param _list The list to search in.
     /// @param _id The address of the current account.
     /// @return The address of the previous account.
-    function getPrev(List storage _list, address _id) internal view returns (address) {
+    function getPrev(List storage _list, uint128 _id) internal view returns (uint128) {
         return _list.accounts[_id].prev;
     }
 
@@ -47,12 +47,12 @@ library BucketDLL {
     /// @dev This function should not be called with `_id` equal to address 0.
     /// @param _list The list to search in.
     /// @param _id The address of the account.
-    function remove(List storage _list, address _id) internal returns (bool empty) {
+    function remove(List storage _list, uint128 _id) internal returns (bool empty) {
         Account memory account = _list.accounts[_id];
-        address prev = account.prev;
-        address next = account.next;
+        uint128 prev = account.prev;
+        uint128 next = account.next;
 
-        empty = (prev == address(0) && next == address(0));
+        empty = (prev == 0 && next == 0);
 
         _list.accounts[prev].next = next;
         _list.accounts[next].prev = prev;
@@ -64,11 +64,11 @@ library BucketDLL {
     /// @dev This function should not be called with `_id` equal to address 0.
     /// @param _list The list to search in.
     /// @param _id The address of the account.
-    function insert(List storage _list, address _id) internal returns (bool empty) {
-        address tail = _list.accounts[address(0)].prev;
-        empty = tail == address(0);
+    function insert(List storage _list, uint128 _id) internal returns (bool empty) {
+        uint128 tail = _list.accounts[0].prev;
+        empty = tail == 0;
 
-        _list.accounts[address(0)].prev = _id;
+        _list.accounts[0].prev = _id;
         _list.accounts[tail].next = _id;
         _list.accounts[_id].prev = tail;
     }

--- a/src/LogarithmicBuckets.sol
+++ b/src/LogarithmicBuckets.sol
@@ -8,7 +8,7 @@ library LogarithmicBuckets {
 
     struct BucketList {
         mapping(uint256 => BucketDLL.List) lists;
-        mapping(address => uint256) valueOf;
+        mapping(uint128 => uint256) valueOf;
         uint256 bucketsMask;
     }
 
@@ -25,10 +25,10 @@ library LogarithmicBuckets {
     /// @notice Updates an account in the `_buckets`.
     function update(
         BucketList storage _buckets,
-        address _id,
+        uint128 _id,
         uint256 _newValue
     ) internal {
-        if (_id == address(0)) revert AddressIsZero();
+        if (_id == 0) revert AddressIsZero();
         uint256 value = _buckets.valueOf[_id];
         _buckets.valueOf[_id] = _newValue;
 
@@ -60,7 +60,7 @@ library LogarithmicBuckets {
     /// @param _bucket The mask of the bucket where to remove.
     function _remove(
         BucketList storage _buckets,
-        address _id,
+        uint128 _id,
         uint256 _bucket
     ) private {
         if (_buckets.lists[_bucket].remove(_id))
@@ -75,7 +75,7 @@ library LogarithmicBuckets {
     /// @param _bucket The mask of the bucket where to insert.
     function _insert(
         BucketList storage _buckets,
-        address _id,
+        uint128 _id,
         uint256 _bucket
     ) private {
         if (_buckets.lists[_bucket].insert(_id)) _buckets.bucketsMask |= _bucket;
@@ -125,7 +125,7 @@ library LogarithmicBuckets {
     /// @notice Returns the address at the head or at the tail of the double linked list.
     /// @param _list The list from which to get the first address.
     /// @param _getHead True to return the head, false to return the tail.
-    function _getFirst(BucketDLL.List storage _list, bool _getHead) private view returns (address) {
+    function _getFirst(BucketDLL.List storage _list, bool _getHead) private view returns (uint128) {
         if (_getHead) return _list.getHead();
         return _list.getTail();
     }
@@ -135,7 +135,7 @@ library LogarithmicBuckets {
     /// @notice Returns the value of `_id`.
     /// @param _buckets The buckets to search in.
     /// @param _id The address of the account.
-    function getValueOf(BucketList storage _buckets, address _id) internal view returns (uint256) {
+    function getValueOf(BucketList storage _buckets, uint128 _id) internal view returns (uint256) {
         return _buckets.valueOf[_id];
     }
 
@@ -160,9 +160,9 @@ library LogarithmicBuckets {
         BucketList storage _buckets,
         uint256 _value,
         bool _fifo
-    ) internal view returns (address) {
+    ) internal view returns (uint128) {
         uint256 bucketsMask = _buckets.bucketsMask;
-        if (bucketsMask == 0) return address(0);
+        if (bucketsMask == 0) return 0;
         uint256 lowerMask = _setLowerBits(_value);
 
         uint256 next = _nextBucket(lowerMask, bucketsMask);

--- a/test/TestBucketDLL.t.sol
+++ b/test/TestBucketDLL.t.sol
@@ -8,42 +8,42 @@ contract TestBucketDLL is Test {
     using BucketDLL for BucketDLL.List;
 
     uint256 internal numberOfAccounts = 50;
-    address[] public accounts;
+    uint128[] public accounts;
 
     BucketDLL.List internal list;
 
     function setUp() public {
-        accounts = new address[](numberOfAccounts);
-        accounts[0] = address(bytes20(keccak256("TestBucketDLL.accounts")));
+        accounts = new uint128[](numberOfAccounts);
+        accounts[0] = uint128(bytes16(keccak256("TestBucketDLL.accounts")));
         for (uint256 i = 1; i < numberOfAccounts; i++) {
-            accounts[i] = address(uint160(accounts[i - 1]) + 1);
+            accounts[i] = uint128(accounts[i - 1] + 1);
         }
     }
 
-    function testInsertOneSingleAccount(address _account) public {
-        vm.assume(_account != address(0));
+    function testInsertOneSingleAccount(uint128 _account) public {
+        vm.assume(_account != 0);
 
         list.insert(_account);
         assertEq(list.getHead(), _account);
         assertEq(list.getTail(), _account);
-        assertEq(list.getPrev(_account), address(0));
-        assertEq(list.getNext(_account), address(0));
+        assertEq(list.getPrev(_account), 0);
+        assertEq(list.getNext(_account), 0);
     }
 
-    function testShouldRemoveOneSingleAccount(address _account) public {
-        vm.assume(_account != address(0));
+    function testShouldRemoveOneSingleAccount(uint128 _account) public {
+        vm.assume(_account != 0);
 
         list.insert(_account);
         list.remove(_account);
 
-        assertEq(list.getHead(), address(0));
-        assertEq(list.getTail(), address(0));
-        assertEq(list.getPrev(_account), address(0));
-        assertEq(list.getNext(_account), address(0));
+        assertEq(list.getHead(), 0);
+        assertEq(list.getTail(), 0);
+        assertEq(list.getPrev(_account), 0);
+        assertEq(list.getNext(_account), 0);
     }
 
-    function testShouldInsertTwoAccounts(address _account0, address _account1) public {
-        vm.assume(_account0 != address(0) && _account1 != address(0));
+    function testShouldInsertTwoAccounts(uint128 _account0, uint128 _account1) public {
+        vm.assume(_account0 != 0 && _account1 != 0);
         vm.assume(_account0 != _account1);
 
         list.insert(_account0);
@@ -51,18 +51,18 @@ contract TestBucketDLL is Test {
 
         assertEq(list.getHead(), _account0);
         assertEq(list.getTail(), _account1);
-        assertEq(list.getPrev(_account0), address(0));
+        assertEq(list.getPrev(_account0), 0);
         assertEq(list.getNext(_account0), _account1);
         assertEq(list.getPrev(_account1), _account0);
-        assertEq(list.getNext(_account1), address(0));
+        assertEq(list.getNext(_account1), 0);
     }
 
     function testShouldInsertThreeAccounts(
-        address _account0,
-        address _account1,
-        address _account2
+        uint128 _account0,
+        uint128 _account1,
+        uint128 _account2
     ) public {
-        vm.assume(_account0 != address(0) && _account1 != address(0) && _account2 != address(0));
+        vm.assume(_account0 != 0 && _account1 != 0 && _account2 != 0);
         vm.assume(_account0 != _account1 && _account1 != _account2 && _account2 != _account0);
 
         list.insert(_account0);
@@ -71,16 +71,16 @@ contract TestBucketDLL is Test {
 
         assertEq(list.getHead(), _account0);
         assertEq(list.getTail(), _account2);
-        assertEq(list.getPrev(_account0), address(0));
+        assertEq(list.getPrev(_account0), 0);
         assertEq(list.getNext(_account0), _account1);
         assertEq(list.getPrev(_account1), _account0);
         assertEq(list.getNext(_account1), _account2);
         assertEq(list.getPrev(_account2), _account1);
-        assertEq(list.getNext(_account2), address(0));
+        assertEq(list.getNext(_account2), 0);
     }
 
-    function testShouldRemoveOneAccountOverTwo(address _account0, address _account1) public {
-        vm.assume(_account0 != address(0) && _account1 != address(0));
+    function testShouldRemoveOneAccountOverTwo(uint128 _account0, uint128 _account1) public {
+        vm.assume(_account0 != 0 && _account1 != 0);
         vm.assume(_account0 != _account1);
 
         list.insert(_account0);
@@ -89,14 +89,14 @@ contract TestBucketDLL is Test {
 
         assertEq(list.getHead(), _account1);
         assertEq(list.getTail(), _account1);
-        assertEq(list.getPrev(_account0), address(0));
-        assertEq(list.getNext(_account0), address(0));
-        assertEq(list.getPrev(_account1), address(0));
-        assertEq(list.getNext(_account1), address(0));
+        assertEq(list.getPrev(_account0), 0);
+        assertEq(list.getNext(_account0), 0);
+        assertEq(list.getPrev(_account1), 0);
+        assertEq(list.getNext(_account1), 0);
     }
 
-    function testShouldRemoveBothAccounts(address _account0, address _account1) public {
-        vm.assume(_account0 != address(0) && _account1 != address(0));
+    function testShouldRemoveBothAccounts(uint128 _account0, uint128 _account1) public {
+        vm.assume(_account0 != 0 && _account1 != 0);
         vm.assume(_account0 != _account1);
 
         list.insert(_account0);
@@ -104,16 +104,16 @@ contract TestBucketDLL is Test {
         list.remove(_account0);
         list.remove(_account1);
 
-        assertEq(list.getHead(), address(0));
-        assertEq(list.getTail(), address(0));
+        assertEq(list.getHead(), 0);
+        assertEq(list.getTail(), 0);
     }
 
     function testShouldInsertThreeAccountsAndRemoveThem(
-        address _account0,
-        address _account1,
-        address _account2
+        uint128 _account0,
+        uint128 _account1,
+        uint128 _account2
     ) public {
-        vm.assume(_account0 != address(0) && _account1 != address(0) && _account2 != address(0));
+        vm.assume(_account0 != 0 && _account1 != 0 && _account2 != 0);
         vm.assume(_account0 != _account1 && _account1 != _account2 && _account2 != _account0);
 
         list.insert(_account0);
@@ -127,23 +127,23 @@ contract TestBucketDLL is Test {
         list.remove(_account1);
         assertEq(list.getHead(), _account0);
         assertEq(list.getTail(), _account2);
-        assertEq(list.getPrev(_account0), address(0));
+        assertEq(list.getPrev(_account0), 0);
         assertEq(list.getNext(_account0), _account2);
 
         assertEq(list.getPrev(_account2), _account0);
-        assertEq(list.getNext(_account2), address(0));
+        assertEq(list.getNext(_account2), 0);
 
         // Remove account 0.
         list.remove(_account0);
         assertEq(list.getHead(), _account2);
         assertEq(list.getTail(), _account2);
-        assertEq(list.getPrev(_account2), address(0));
-        assertEq(list.getNext(_account2), address(0));
+        assertEq(list.getPrev(_account2), 0);
+        assertEq(list.getNext(_account2), 0);
 
         // Remove account 2.
         list.remove(_account2);
-        assertEq(list.getHead(), address(0));
-        assertEq(list.getTail(), address(0));
+        assertEq(list.getHead(), 0);
+        assertEq(list.getTail(), 0);
     }
 
     function testShouldInsertAccountsInFIFOOrder() public {
@@ -154,13 +154,13 @@ contract TestBucketDLL is Test {
         assertEq(list.getHead(), accounts[0]);
         assertEq(list.getTail(), accounts[accounts.length - 1]);
 
-        address nextAccount = accounts[0];
+        uint128 nextAccount = accounts[0];
         for (uint256 i = 0; i < accounts.length - 1; i++) {
             nextAccount = list.getNext(nextAccount);
             assertEq(nextAccount, accounts[i + 1]);
         }
 
-        address prevAccount = accounts[accounts.length - 1];
+        uint128 prevAccount = accounts[accounts.length - 1];
         for (uint256 i = accounts.length - 2; i > 0; i--) {
             prevAccount = list.getPrev(prevAccount);
             assertEq(prevAccount, accounts[i]);
@@ -176,7 +176,7 @@ contract TestBucketDLL is Test {
             list.remove(accounts[i]);
         }
 
-        assertEq(list.getHead(), address(0));
-        assertEq(list.getTail(), address(0));
+        assertEq(list.getHead(), 0);
+        assertEq(list.getTail(), 0);
     }
 }

--- a/test/TestLogarithmicBuckets.t.sol
+++ b/test/TestLogarithmicBuckets.t.sol
@@ -9,19 +9,19 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
     using LogarithmicBuckets for LogarithmicBuckets.BucketList;
 
     uint256 public NDS = 50;
-    address[] public accounts;
-    address public ADDR_ZERO = address(0);
+    uint128[] public accounts;
+    uint128 public ADDR_ZERO = uint128(0);
 
     function setUp() public {
-        accounts = new address[](NDS);
-        accounts[0] = address(bytes20(keccak256("TestLogarithmicBuckets.accounts")));
+        accounts = new uint128[](NDS);
+        accounts[0] = uint128(bytes16(keccak256("TestLogarithmicBuckets.accounts")));
         for (uint256 i = 1; i < NDS; i++) {
-            accounts[i] = address(uint160(accounts[i - 1]) + 1);
+            accounts[i] = accounts[i - 1] + 1;
         }
     }
 
     function testEmpty(uint256 _value, bool _fifo) public {
-        assertEq(bucketList.getMatch(_value, _fifo), address(0));
+        assertEq(bucketList.getMatch(_value, _fifo), uint128(0));
     }
 
     function testInsertOneSingleAccount() public {
@@ -40,7 +40,7 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
 
     function testShouldNotInsertZeroAddress() public {
         vm.expectRevert(abi.encodeWithSignature("AddressIsZero()"));
-        bucketList.update(address(0), 10);
+        bucketList.update(uint128(0), 10);
     }
 
     function testShouldHaveTheRightOrderWithinABucket() public {
@@ -49,9 +49,9 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
         bucketList.update(accounts[2], 16);
 
         BucketDLL.List storage list = bucketList.getBucketOf(16);
-        address head = list.getNext(address(0));
-        address next1 = list.getNext(head);
-        address next2 = list.getNext(next1);
+        uint128 head = list.getNext(uint128(0));
+        uint128 next1 = list.getNext(head);
+        uint128 next2 = list.getNext(next1);
         assertEq(head, accounts[0]);
         assertEq(next1, accounts[1]);
         assertEq(next2, accounts[2]);
@@ -62,8 +62,8 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
         bucketList.update(accounts[0], 0);
 
         assertEq(bucketList.getValueOf(accounts[0]), 0);
-        assertEq(bucketList.getMatch(0, true), address(0));
-        assertEq(bucketList.getBucketOf(1).getHead(), address(0));
+        assertEq(bucketList.getMatch(0, true), uint128(0));
+        assertEq(bucketList.getBucketOf(1).getHead(), uint128(0));
     }
 
     function testShouldInsertTwoAccounts() public {
@@ -84,7 +84,7 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
         assertEq(bucketList.getValueOf(accounts[0]), 0);
         assertEq(bucketList.getValueOf(accounts[1]), 16);
         assertEq(bucketList.getBucketOf(16).getHead(), accounts[1]);
-        assertEq(bucketList.getBucketOf(4).getHead(), address(0));
+        assertEq(bucketList.getBucketOf(4).getHead(), uint128(0));
     }
 
     function testShouldRemoveBothAccounts() public {
@@ -93,12 +93,12 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
         bucketList.update(accounts[0], 0);
         bucketList.update(accounts[1], 0);
 
-        assertEq(bucketList.getMatch(4, true), address(0));
+        assertEq(bucketList.getMatch(4, true), uint128(0));
     }
 
     function testGetMatch() public {
-        assertEq(bucketList.getMatch(0, true), address(0));
-        assertEq(bucketList.getMatch(1000, true), address(0));
+        assertEq(bucketList.getMatch(0, true), uint128(0));
+        assertEq(bucketList.getMatch(1000, true), uint128(0));
 
         bucketList.update(accounts[0], 16);
         assertEq(bucketList.getMatch(1, true), accounts[0], "head before");

--- a/test/TestLogarithmicBucketsGas.t.sol
+++ b/test/TestLogarithmicBucketsGas.t.sol
@@ -33,16 +33,16 @@ contract TestLogarithmicBucketsGas is Test {
             if (amount % 4 < 2) {
                 // Measure insert.
                 startGasMetering();
-                bucketList.update(address(uint160(amount)), amount);
+                bucketList.update(uint128(amount), amount);
                 insertCost += stopGasMetering();
                 insertCount++;
             }
             // Update value in same bucket (p=1/4).
             else if (amount % 4 == 2) {
                 // Get an account to update its value.
-                address toUpdate = bucketList.getMatch(amount, true);
+                uint128 toUpdate = bucketList.getMatch(amount, true);
 
-                if (toUpdate != address(0)) {
+                if (toUpdate != 0) {
                     // Measure updateValue.
                     startGasMetering();
                     bucketList.update(toUpdate, amount);
@@ -54,11 +54,11 @@ contract TestLogarithmicBucketsGas is Test {
             else {
                 // Measure getMatch.
                 startGasMetering();
-                address toUpdate = bucketList.getMatch(amount, true);
+                uint128 toUpdate = bucketList.getMatch(amount, true);
                 getMatchCost += stopGasMetering();
                 getMatchCount++;
 
-                if (toUpdate != address(0)) {
+                if (toUpdate != 0) {
                     // Measure remove.
                     startGasMetering();
                     bucketList.update(bucketList.getMatch(amount, true), 0);

--- a/test/TestLogarithmicBucketsInvariant.t.sol
+++ b/test/TestLogarithmicBucketsInvariant.t.sol
@@ -19,20 +19,20 @@ contract TestLogarithmicBucketsInvariant is Test, Random {
 
     // Check that the address 0 is never inserted in the buckets.
     function invariantZeroAccountIsNotInserted() public {
-        assertEq(buckets.getValueOf(address(0)), 0);
+        assertEq(buckets.getValueOf(0), 0);
     }
 
     // Check that if the buckets are not all empty, then matching returns some non zero address.
     function invariantGetMatchFIFO() public {
         bool notEmpty = buckets.maxBucket() != 0;
         uint256 value = randomUint256();
-        assertTrue(!notEmpty || buckets.getMatch(value, true) != address(0));
+        assertTrue(!notEmpty || buckets.getMatch(value, true) != 0);
     }
 
     function invariantGetMatchLIFO() public {
         bool notEmpty = buckets.maxBucket() != 0;
         uint256 value = randomUint256();
-        assertTrue(!notEmpty || buckets.getMatch(value, false) != address(0));
+        assertTrue(!notEmpty || buckets.getMatch(value, false) != 0);
     }
 }
 
@@ -40,14 +40,14 @@ contract LogarithmicBucketsSeenMock is LogarithmicBucketsMock {
     using BucketDLL for BucketDLL.List;
     using LogarithmicBuckets for LogarithmicBuckets.BucketList;
 
-    address[] public seen;
-    mapping(address => bool) public isSeen;
+    uint128[] public seen;
+    mapping(uint128 => bool) public isSeen;
 
     function seenLength() public view returns (uint256) {
         return seen.length;
     }
 
-    function update(address _id, uint256 _newValue) public override {
+    function update(uint128 _id, uint256 _newValue) public override {
         if (!isSeen[_id]) {
             isSeen[_id] = true;
             seen.push(_id);
@@ -56,12 +56,12 @@ contract LogarithmicBucketsSeenMock is LogarithmicBucketsMock {
         super.update(_id, _newValue);
     }
 
-    function getPrev(uint256 _value, address _id) public view returns (address) {
+    function getPrev(uint256 _value, uint128 _id) public view returns (uint128) {
         BucketDLL.List storage bucket = bucketList.getBucketOf(_value);
         return bucket.getPrev(_id);
     }
 
-    function getNext(uint256 _value, address _id) public view returns (address) {
+    function getNext(uint256 _value, uint128 _id) public view returns (uint128) {
         BucketDLL.List storage bucket = bucketList.getBucketOf(_value);
         return bucket.getNext(_id);
     }
@@ -76,11 +76,11 @@ contract TestLogarithmicBucketsSeenInvariant is Test, Random {
 
     function invariantNotZeroAccountIsInserted() public {
         for (uint256 i; i < buckets.seenLength(); i++) {
-            address user = buckets.seen(i);
+            uint128 user = buckets.seen(i);
             uint256 value = buckets.getValueOf(user);
             if (value != 0) {
-                address next = buckets.getNext(value, user);
-                address prev = buckets.getPrev(value, user);
+                uint128 next = buckets.getNext(value, user);
+                uint128 prev = buckets.getPrev(value, user);
                 assertEq(buckets.getNext(value, prev), user);
                 assertEq(buckets.getPrev(value, next), user);
             }

--- a/test/mocks/LogarithmicBucketsMock.sol
+++ b/test/mocks/LogarithmicBucketsMock.sol
@@ -9,11 +9,11 @@ contract LogarithmicBucketsMock {
 
     LogarithmicBuckets.BucketList public bucketList;
 
-    function update(address _id, uint256 _newValue) public virtual {
+    function update(uint128 _id, uint256 _newValue) public virtual {
         bucketList.update(_id, _newValue);
     }
 
-    function getValueOf(address _id) public view returns (uint256) {
+    function getValueOf(uint128 _id) public view returns (uint256) {
         return bucketList.getValueOf(_id);
     }
 
@@ -35,7 +35,7 @@ contract LogarithmicBucketsMock {
         return lowerMask ^ (lowerMask >> 1);
     }
 
-    function getMatch(uint256 _value, bool _fifo) public view returns (address) {
+    function getMatch(uint256 _value, bool _fifo) public view returns (uint128) {
         return bucketList.getMatch(_value, _fifo);
     }
 
@@ -49,7 +49,7 @@ contract LogarithmicBucketsMock {
 
             BucketDLL.List storage list = bucketList.getBucketOf(lowerValue);
 
-            for (address id = list.getHead(); id != address(0); id = list.getNext(id)) {
+            for (uint128 id = list.getHead(); id != 0; id = list.getNext(id)) {
                 uint256 value = bucketList.getValueOf(id);
                 if (value < lowerValue || value > higherValue) return false;
             }


### PR DESCRIPTION
The idea is to pack the `Account` struct which stores 2 addresses.

Pro:
- about 30% gas reduction

Cons:
- security with the unlikely case of hash collision. Note that 128 bits security is [considered safe](https://en.wikipedia.org/wiki/Security_level)
- some changes to do in the main contracts
- readability

Note that we will not lose type safety:
- much right now, if we just change address into uint128, because there are only a few place where we use uint128 in our contracts
- at all, if we use a type alias such as `type addr is uint128`. Note that this solution also solves the readability issue

Before:
![before-packing](https://user-images.githubusercontent.com/22668539/212116625-cfb68710-e4fe-4296-8cd7-7b516fe11f1a.png)

After:
![after-packing](https://user-images.githubusercontent.com/22668539/212116724-04087eff-d113-4919-b996-f8fa632ff01e.png)
