### PR TITLE
Rename symtest to halmos

### DIFF
--- a/.github/workflows/ci-foundry.yml
+++ b/.github/workflows/ci-foundry.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run tests
         run: forge test
 
-      - name: Install symtest
-        run: python3 -m pip install --upgrade symtest
+      - name: Install halmos
+        run: python3 -m pip install --upgrade halmos
 
-      - name: Run symtest
-        run: symtest --function testProve --loop 4
+      - name: Run halmos
+        run: halmos --function testProve --loop 4


### PR DESCRIPTION
The `symtest` tool has been released under a new name: [Halmos](https://github.com/a16z/halmos). You can read more about it on the [post](https://a16zcrypto.com/symbolic-testing-with-halmos-leveraging-existing-tests-for-formal-verification/).