### PR TITLE
test: update halmos test

### DIFF
--- a/test/TestLogarithmicBuckets.t.sol
+++ b/test/TestLogarithmicBuckets.t.sol
@@ -115,7 +115,9 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
         assertEq(buckets.getMatch(16), accounts[0], "head equal");
         assertEq(buckets.getMatch(32), accounts[0], "head above");
     }
+}
 
+contract TestProveLogarithmicBuckets is LogarithmicBucketsMock, Test {
     function isPowerOfTwo(uint256 x) public pure returns (bool) {
         unchecked {
             return x != 0 && (x & (x - 1)) == 0;


### PR DESCRIPTION
In the [latest version](https://github.com/a16z/halmos/releases/tag/v0.0.3), Halmos recognizes and executes a given setUp() function, but it currently fails to execute the setUp() function of TestLogarithmicBuckets due to missing features. This little refactoring avoids the issue in the meantime.