### PR TITLE
Remove useless getters `BucketDLL`

### DIFF
--- a/src/BucketDLL.sol
+++ b/src/BucketDLL.sol
@@ -15,34 +15,13 @@ library BucketDLL {
 
     /* INTERNAL */
 
-    /// @notice Returns the address at the head of the `list`.
-    /// @param list The list from which to get the head.
-    /// @return The address of the head.
-    function getHead(List storage list) internal view returns (address) {
-        return list.accounts[address(0)].next;
-    }
-
-    /// @notice Returns the address at the tail of the `list`.
-    /// @param list The list from which to get the tail.
-    /// @return The address of the tail.
-    function getTail(List storage list) internal view returns (address) {
-        return list.accounts[address(0)].prev;
-    }
-
     /// @notice Returns the next id address from the current `id`.
+    /// @dev getNext(address(0)) returns the head.
     /// @param list The list to search in.
     /// @param id The address of the current account.
     /// @return The address of the next account.
     function getNext(List storage list, address id) internal view returns (address) {
         return list.accounts[id].next;
-    }
-
-    /// @notice Returns the previous id address from the current `id`.
-    /// @param list The list to search in.
-    /// @param id The address of the current account.
-    /// @return The address of the previous account.
-    function getPrev(List storage list, address id) internal view returns (address) {
-        return list.accounts[id].prev;
     }
 
     /// @notice Removes an account of the `list`.


### PR DESCRIPTION
- Remove `getHead`, `getTail`, and `getPrev` as they are not used.
- Add a comment on `getNext` to get the head.