### PR TITLE
Update CI to install the latest micro version of Python

### DIFF
--- a/.github/workflows/ci-foundry.yml
+++ b/.github/workflows/ci-foundry.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
`actions/setup-python@v4` is added in CI to ensures that the latest micro version of Python is installed, instead of the version that comes with the ubuntu-latest.